### PR TITLE
feat(logger): add logging to HTTP requests

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -17,6 +17,7 @@ import isAxiosError from './helpers/isAxiosError.js';
 import AxiosHeaders from "./core/AxiosHeaders.js";
 import adapters from './adapters/adapters.js';
 import HttpStatusCode from './helpers/HttpStatusCode.js';
+import * as RequestLogger from './logger/requestLogger.js'
 
 /**
  * Create an instance of Axios
@@ -35,6 +36,12 @@ function createInstance(defaultConfig) {
   // Copy context to instance
   utils.extend(instance, context, null, {allOwnKeys: true});
 
+  // Attach logging APIs
+  instance.enable_request_logging = RequestLogger.enable_request_logging;
+  instance.disable_request_logging = RequestLogger.disable_request_logging;
+  instance.get_request_log = RequestLogger.get_request_log;
+  instance.clear_request_log = RequestLogger.clear_request_log;
+
   // Factory for creating new instances
   instance.create = function create(instanceConfig) {
     return createInstance(mergeConfig(defaultConfig, instanceConfig));
@@ -45,6 +52,18 @@ function createInstance(defaultConfig) {
 
 // Create the default instance to be exported
 const axios = createInstance(defaults);
+
+// Logs successful and error responses if logging is enabled
+axios.interceptors.response.use(
+    response => {
+      RequestLogger.logResponse(response);
+      return response;
+    },
+    error => {
+      RequestLogger.logError(error);
+      return Promise.reject(error);
+    }
+);
 
 // Expose Axios class to allow class inheritance
 axios.Axios = Axios;

--- a/lib/logger/requestLogger.js
+++ b/lib/logger/requestLogger.js
@@ -1,0 +1,50 @@
+let isLoggingEnabled = false;
+const requestLog = [];
+
+
+export function enable_request_logging() {
+    isLoggingEnabled = true;
+}
+
+// Disables request logging for this axios instance
+export function disable_request_logging() {
+    isLoggingEnabled = false;
+}
+
+// Returns a copy of the current request log
+export function get_request_log () {
+    return [...requestLog];
+}
+
+// Clears all the logged request entries
+export function clear_request_log () {
+    requestLog.length = 0;
+}
+
+/**
+ * Logs a successful response.
+ * @param {Object} response - The Axios response object.
+ */
+export function logResponse(response) {
+    if (isLoggingEnabled) {
+        requestLog.push({
+            method: response.config.method.toUpperCase(),
+            url: response.config.url,
+            status: response.status
+        });
+    }
+}
+
+/**
+ * Logs an error response if available.
+ * @param {Object} error - The Axios error object.
+ */
+export function logError(error) {
+    if (isLoggingEnabled && error.response) {
+        requestLog.push({
+            method: error.config.method.toUpperCase(),
+            url: error.config.url,
+            status: error.response.status
+        });
+    }
+}

--- a/test/unit/logger/requestLogger.js
+++ b/test/unit/logger/requestLogger.js
@@ -1,0 +1,149 @@
+import axios from '../../../lib/axios.js'
+import assert from 'assert';
+
+
+const originalAdapter = axios.defaults.adapter;
+
+const STUB_RESPONSES = {
+    GET: {
+        data: {message: 'GET stub'},
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        request: {}
+    },
+    POST: {
+        data: {message: 'POST stub'},
+        status: 200,
+        statusText: '',
+        headers: {},
+        request: {}
+    },
+    PUT: {
+        data: {message: 'ERROR stub'},
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: {},
+    }
+}
+
+const stubAdapter = (config) => {
+    const method = config.method.toLowerCase();
+    if (method === 'get') {
+        return Promise.resolve({...STUB_RESPONSES.GET, config});
+    } else if (method === 'post') {
+        return Promise.resolve({...STUB_RESPONSES.POST, config});
+    } else if (method === 'put') {
+        return Promise.resolve({...STUB_RESPONSES.PUT, config});
+    } else {
+        return Promise.reject(new Error(`Unexpected request: ${config.method} ${config.url}`));
+    }
+}
+
+describe('Axios Request Logging', () => {
+    beforeEach(() => {
+        axios.clear_request_log();
+        axios.disable_request_logging();
+        axios.defaults.adapter = originalAdapter;
+    });
+
+    afterEach(() => {
+        axios.defaults.adapter = originalAdapter;
+    });
+
+
+
+    it("Should log when logging is not disabled", async () => {
+
+        axios.defaults.adapter = stubAdapter;
+
+        axios.enable_request_logging();
+        await axios.get('https://httpbin.org/get');
+        const logs = axios.get_request_log();
+
+        assert.strictEqual(logs.length, 1);
+        assert.strictEqual(logs[0].method,'GET');
+        assert.strictEqual(logs[0].url,'https://httpbin.org/get');
+        assert.strictEqual(logs[0].status,200);
+    });
+
+    it("Should not log when logging is disabled", async () => {
+
+        axios.defaults.adapter = stubAdapter;
+
+        await axios.get('https://httpbin.org/get');
+        const logs = axios.get_request_log();
+
+        assert.strictEqual(logs.length, 0);
+    });
+
+    it("Should log an error request when logging is not disabled", async () => {
+
+        axios.defaults.adapter = stubAdapter;
+        axios.enable_request_logging();
+        await axios.put('https://httpbin.org/put');
+        const logs = axios.get_request_log();
+
+        assert.strictEqual(logs.length, 1);
+        assert.strictEqual(logs[0].method,'PUT');
+        assert.strictEqual(logs[0].url,'https://httpbin.org/put');
+        assert.strictEqual(logs[0].status,500);
+    });
+
+    it("Should log multiple requests when logging is not disabled", async () => {
+
+        axios.defaults.adapter = stubAdapter;
+        axios.enable_request_logging();
+        await axios.get('https://httpbin.org/get');
+        await axios.post('https://httpbin.org/post');
+        await axios.put('https://httpbin.org/put');
+        const logs = axios.get_request_log();
+        const expectedLogs = [
+            { method: 'GET', url: 'https://httpbin.org/get', status: 200 },
+            { method: 'POST', url: 'https://httpbin.org/post', status: 200 },
+            { method: 'PUT', url: 'https://httpbin.org/put', status: 500}
+        ];
+
+        assert.strictEqual(logs.length, 3);
+        assert.deepStrictEqual(logs, expectedLogs);
+    });
+
+    it("Should log multiple requests the clear successfully", async () => {
+
+        axios.defaults.adapter = stubAdapter;
+        axios.enable_request_logging();
+        await axios.get('https://httpbin.org/get');
+        await axios.post('https://httpbin.org/post');
+
+        const logs = axios.get_request_log();
+        const expectedLogs = [
+            { method: 'GET', url: 'https://httpbin.org/get', status: 200 },
+            { method: 'POST', url: 'https://httpbin.org/post', status: 200 }
+        ];
+
+        assert.strictEqual(logs.length, 2);
+        assert.deepStrictEqual(logs, expectedLogs);
+
+        axios.clear_request_log();
+        const logsCleared = axios.get_request_log();
+        assert.strictEqual(logsCleared.length, 0);
+    });
+
+    it("Should not log an error if error.response is undefined - no response exists", async () => {
+        axios.defaults.adapter = (config) => {
+            const error = new Error("Network error");
+            error.config = config;
+            return Promise.reject(error);
+        };
+
+        axios.enable_request_logging();
+        try {
+            await axios.get("https://httpbin.org/get");
+        } catch(error) {
+            // Expected error
+        }
+
+        const logs = axios.get_request_log();
+        assert.strictEqual(logs.length, 0);
+    });
+});


### PR DESCRIPTION
This pull request introduces a lightweight request logging feature into the Axios HTTP client library with a logging functionality that would enable developers to trace and debug network behaviour more easily by capturing key metadata (HTTP method, URL, and HTTP status) for each HTTP request made by Axios.

**Key Changes:**

New Public API Methods:

- `enable_request_logging()`: Enables logging for all subsequent HTTP requests.
- `disable_request_logging()`: Disables logging.
- `get_request_log()`: Returns a shallow copy of the current log, containing each request's metadata.
- `clear_request_log()`: Clears all logged entries.

**Logging Integration:**

- The logging functionality is integrated directly into the Axios core via response interceptors.
- Both successful responses and error responses (when a response is available) are logged.
- The actual logging logic was refactored into a separate module (`lib/logger/requestLogger.js`) 

**Tests and Verification:**

- A new test suite (`test/unit/logger/logger.js`) was created to verify the logging functionality.

- Tests cover:
  - Successful and error requests.
  - The behaviour when logging is disabled.
  - The correct logging of multiple requests.
  - Log clearing functionality.
  - An edge case where errors without a response are not logged.

- All tests have been run locally and pass successfully.